### PR TITLE
Reorder upload and security middlewares

### DIFF
--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -149,19 +149,6 @@ export class OpenApiValidator {
         .catch(next);
     });
 
-    if (this.options.fileUploader) {
-      // multipart middleware
-      let fumw;
-      middlewares.push(function multipartMiddleware(req, res, next) {
-        return pContext
-          .then(({ context: { apiDoc } }) => {
-            fumw = fumw || self.multipartMiddleware(apiDoc);
-            return fumw(req, res, next);
-          })
-          .catch(next);
-      });
-    }
-
     // security middlware
     let scmw;
     middlewares.push(function securityMiddleware(req, res, next) {
@@ -177,6 +164,19 @@ export class OpenApiValidator {
         })
         .catch(next);
     });
+
+    if (this.options.fileUploader) {
+      // multipart middleware
+      let fumw;
+      middlewares.push(function multipartMiddleware(req, res, next) {
+        return pContext
+          .then(({ context: { apiDoc } }) => {
+            fumw = fumw || self.multipartMiddleware(apiDoc);
+            return fumw(req, res, next);
+          })
+          .catch(next);
+      });
+    }
 
     // request middlweare
     if (this.options.validateRequests) {


### PR DESCRIPTION
- Move multipart middleware after security middleware so that security handlers can abort request pipeline before uploads are processed.

Fixes #865